### PR TITLE
breaking! make ellipsis configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ cmp.setup {
     format = lspkind.cmp_format({
       mode = 'symbol', -- show only symbol annotations
       maxwidth = 50, -- prevent the popup from showing more than provided characters (e.g 50 will not show more than 50 characters)
+      ellipsis_char = '...', -- when popup menu exceed maxwidth, the truncated part would show ellipsis_char instead (must define maxwidth first)
 
       -- The function below will be called before any actual modifications from lspkind
       -- so that you can provide more controls on popup customization. (See [#30](https://github.com/onsails/lspkind-nvim/pull/30))

--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -198,12 +198,13 @@ function lspkind.cmp_format(opts)
 
     if opts.maxwidth ~= nil then
       if opts.ellipsis_char == nil then
-        opts.ellipsis_char = "..."
-      end
-      local label = vim_item.abbr
-      local truncated_label = vim.fn.strcharpart(label, 0, opts.maxwidth)
-      if truncated_label ~= label then
-        vim_item.abbr = truncated_label .. opts.ellipsis_char
+        vim_item.abbr = string.sub(vim_item.abbr, 1, opts.maxwidth)
+      else
+        local label = vim_item.abbr
+        local truncated_label = vim.fn.strcharpart(label, 0, opts.maxwidth)
+        if truncated_label ~= label then
+          vim_item.abbr = truncated_label .. opts.ellipsis_char
+        end
       end
     end
     return vim_item


### PR DESCRIPTION
I would like to `ellipsis_char` to be configurable. When the value is `nil`, then not show anything. Or define whatever you like.