### PR TITLE
vim_item.menu is overwritten when setting the kind

### DIFF
--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -193,7 +193,7 @@ function lspkind.cmp_format(opts)
     vim_item.kind = lspkind.symbolic(vim_item.kind, opts)
 
     if opts.menu ~= nil then
-      vim_item.menu = opts.menu[entry.source.name]
+      vim_item.menu = (vim_item.menu == nil and "" or vim_item.menu) .. (opts.menu[entry.source.name] == nil and "" or opts.menu[entry.source.name])
     end
 
     if opts.maxwidth ~= nil then
@@ -212,3 +212,4 @@ function lspkind.cmp_format(opts)
 end
 
 return lspkind
+

--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -193,7 +193,7 @@ function lspkind.cmp_format(opts)
     vim_item.kind = lspkind.symbolic(vim_item.kind, opts)
 
     if opts.menu ~= nil then
-      vim_item.menu = (vim_item.menu == nil and "" or vim_item.menu) .. (opts.menu[entry.source.name] == nil and "" or opts.menu[entry.source.name])
+      vim_item.menu = (opts.menu[entry.source.name] == nil and "" or opts.menu[entry.source.name]) .. (vim_item.menu == nil and "" or vim_item.menu)
     end
 
     if opts.maxwidth ~= nil then


### PR DESCRIPTION
When `lspkind.nvim` sets the `vim_item.menu` field of an entry, it may overwrite some data already stored in the variable. An example of this is the seldomly employed `labelDetails.description`, which is concatenated by `nvim-cmp` with the `menu` field before the `formatting.format` function is called on the item.
```lua
    if opts.menu ~= nil then
      vim_item.menu = opts.menu[entry.source.name]
    end
```
This simple fix solves the problem.