### PR TITLE
Allow `maxwidth` to be a dynamic function

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ cmp.setup {
     format = lspkind.cmp_format({
       mode = 'symbol', -- show only symbol annotations
       maxwidth = 50, -- prevent the popup from showing more than provided characters (e.g 50 will not show more than 50 characters)
+                     -- can also be a function to dynamically calculate max width such as 
+                     -- maxwidth = function() return math.floor(0.45 * vim.o.columns) end,
       ellipsis_char = '...', -- when popup menu exceed maxwidth, the truncated part would show ellipsis_char instead (must define maxwidth first)
 
       -- The function below will be called before any actual modifications from lspkind

--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -197,11 +197,12 @@ function lspkind.cmp_format(opts)
     end
 
     if opts.maxwidth ~= nil then
+      local maxwidth = type(opts.maxwidth) == "function" and opts.maxwidth() or opts.maxwidth
       if opts.ellipsis_char == nil then
-        vim_item.abbr = string.sub(vim_item.abbr, 1, opts.maxwidth)
+        vim_item.abbr = string.sub(vim_item.abbr, 1, maxwidth)
       else
         local label = vim_item.abbr
-        local truncated_label = vim.fn.strcharpart(label, 0, opts.maxwidth)
+        local truncated_label = vim.fn.strcharpart(label, 0, maxwidth)
         if truncated_label ~= label then
           vim_item.abbr = truncated_label .. opts.ellipsis_char
         end
@@ -212,4 +213,3 @@ function lspkind.cmp_format(opts)
 end
 
 return lspkind
-


### PR DESCRIPTION
Allows `maxwidth` to be dynamic such as calculating a percentage of the width of the editor.

Let me know if this is a change you like. I also know it's possible to just hack this together using the `before` function, but it's also nice to get built in support with the `ellipsis_char` and not having to duplicate truncation code.