### PR TITLE
Disable labelDetails in menu by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ cmp.setup {
                      -- can also be a function to dynamically calculate max width such as 
                      -- maxwidth = function() return math.floor(0.45 * vim.o.columns) end,
       ellipsis_char = '...', -- when popup menu exceed maxwidth, the truncated part would show ellipsis_char instead (must define maxwidth first)
+      show_menu_labelDetails = true, -- show labelDetails in menu. Disabled by default
 
       -- The function below will be called before any actual modifications from lspkind
       -- so that you can provide more controls on popup customization. (See [#30](https://github.com/onsails/lspkind-nvim/pull/30))

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ cmp.setup {
                      -- can also be a function to dynamically calculate max width such as 
                      -- maxwidth = function() return math.floor(0.45 * vim.o.columns) end,
       ellipsis_char = '...', -- when popup menu exceed maxwidth, the truncated part would show ellipsis_char instead (must define maxwidth first)
-      show_menu_labelDetails = true, -- show labelDetails in menu. Disabled by default
+      show_labelDetails = true, -- show labelDetails in menu. Disabled by default
 
       -- The function below will be called before any actual modifications from lspkind
       -- so that you can provide more controls on popup customization. (See [#30](https://github.com/onsails/lspkind-nvim/pull/30))

--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -193,7 +193,7 @@ function lspkind.cmp_format(opts)
     vim_item.kind = lspkind.symbolic(vim_item.kind, opts)
 
     if opts.menu ~= nil then
-      vim_item.menu = opts.menu[entry.source.name]
+      vim_item.menu = (opts.menu[entry.source.name] ~= nil and opts.menu[entry.source.name] or "")
         .. ((opts.show_menu_labelDetails and vim_item.menu ~= nil) and vim_item.menu or "")
     end
 

--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -194,7 +194,7 @@ function lspkind.cmp_format(opts)
 
     if opts.menu ~= nil then
       vim_item.menu = (opts.menu[entry.source.name] ~= nil and opts.menu[entry.source.name] or "")
-        .. ((opts.show_menu_labelDetails and vim_item.menu ~= nil) and vim_item.menu or "")
+        .. ((opts.show_labelDetails and vim_item.menu ~= nil) and vim_item.menu or "")
     end
 
     if opts.maxwidth ~= nil then

--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -193,7 +193,8 @@ function lspkind.cmp_format(opts)
     vim_item.kind = lspkind.symbolic(vim_item.kind, opts)
 
     if opts.menu ~= nil then
-      vim_item.menu = (opts.menu[entry.source.name] == nil and "" or opts.menu[entry.source.name]) .. (vim_item.menu == nil and "" or vim_item.menu)
+      vim_item.menu = opts.menu[entry.source.name]
+        .. ((opts.show_menu_labelDetails and vim_item.menu ~= nil) and vim_item.menu or "")
     end
 
     if opts.maxwidth ~= nil then


### PR DESCRIPTION
Make the labelDetails in menu to be optional. And disabled by default.

Close #74