### PR TITLE
refactor: reduce unneeded code in opt.maxwidth

### DIFF
--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -198,14 +198,9 @@ function lspkind.cmp_format(opts)
 
     if opts.maxwidth ~= nil then
       local maxwidth = type(opts.maxwidth) == "function" and opts.maxwidth() or opts.maxwidth
-      if opts.ellipsis_char == nil then
-        vim_item.abbr = string.sub(vim_item.abbr, 1, maxwidth)
-      else
-        local label = vim_item.abbr
-        local truncated_label = vim.fn.strcharpart(label, 0, maxwidth)
-        if truncated_label ~= label then
-          vim_item.abbr = truncated_label .. opts.ellipsis_char
-        end
+      if vim.fn.strchars(vim_item.abbr) > maxwidth then
+        vim_item.abbr = vim.fn.strcharpart(vim_item.abbr, 0, maxwidth)
+          .. (opts.ellipsis_char ~= nil and opts.ellipsis_char or "")
       end
     end
     return vim_item


### PR DESCRIPTION
I use `vim.fn.strchars` instead of lua `string.len()`. Because `string.len()` returns number of bytes not number of characters. And lua doesn't seem to provide any function for counting characters.