### PR TITLE
feat: add `setup()` as an alias to `init()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This tiny plugin adds vscode-like pictograms to neovim built-in lsp:
 Wherever you configure lsp put the following lua command:
 
 ```lua
+-- setup() is also available as an alias
 require('lspkind').init({
     -- DEPRECATED (use mode instead): enables text annotations
     --

--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -162,6 +162,7 @@ function lspkind.init(opts)
   end
 end
 
+lspkind.setup = lspkind.init
 lspkind.presets = kind_presets
 lspkind.symbol_map = kind_presets.default
 


### PR DESCRIPTION
`setup()` is a more common/standard name for a general plugin configuration function.
And with `lazy.nvim`, it allows you to just specify the `opts` table instead of a whole function call.

```lua
{
  "onsails/lspkind.nvim",
  config = function()
    require("lspkind").init({ 
      -- stuffs
    })
  end,
},
```

```lua
{
  "onsails/lspkind.nvim",
  opts = {
    -- stuffs
  },
},
```

It's a minor QoL improvement, but it also only takes a single line.
What do you think?