### PR TITLE
feat: limit the width of labelDetails

### DIFF
--- a/lua/lspkind/init.lua
+++ b/lua/lspkind/init.lua
@@ -178,6 +178,14 @@ function lspkind.symbolic(kind, opts)
   return formatter(kind)
 end
 
+local function abbreviateString(str, maxwidth, ellipsis_char)
+  if vim.fn.strchars(str) > maxwidth then
+    str = vim.fn.strcharpart(str, 0, maxwidth) .. (ellipsis_char ~= nil and ellipsis_char or "")
+  end
+
+  return str
+end
+
 function lspkind.cmp_format(opts)
   if opts == nil then
     opts = {}
@@ -199,12 +207,13 @@ function lspkind.cmp_format(opts)
     end
 
     if opts.maxwidth ~= nil then
+      local ellipsis_char = opts.ellipsis_char
       local maxwidth = type(opts.maxwidth) == "function" and opts.maxwidth() or opts.maxwidth
-      if vim.fn.strchars(vim_item.abbr) > maxwidth then
-        vim_item.abbr = vim.fn.strcharpart(vim_item.abbr, 0, maxwidth)
-          .. (opts.ellipsis_char ~= nil and opts.ellipsis_char or "")
-      end
+
+      vim_item.abbr = abbreviateString(vim_item.abbr, maxwidth, ellipsis_char)
+      vim_item.menu = abbreviateString(vim_item.menu, maxwidth, ellipsis_char)
     end
+
     return vim_item
   end
 end


### PR DESCRIPTION
`labelDetails` may be very long, it may occupy most of the screen space.

nvim-cmp config:

```lua
format = lspkind.cmp_format({
    preset = "codicons",
    mode = "symbol",
    maxwidth = 20,
    show_labelDetails = true,
    ellipsis_char = "…",
    menu = {
        buffer = "[buf]",
        nvim_lsp = "[LSP]",
        nvim_lua = "[api]",
        path = "[path]",
        luasnip = "[snip]",
        gh_issues = "[issues]",
        tn = "[TabNine]",
        eruby = "[erb]",
    },
}),
```

**before**: Too long, the document will obscure the completion information.
<img width="1295" alt="image" src="https://github.com/user-attachments/assets/5d15611d-fc4b-4dfd-8ccb-015543064cd9">

**after**: No obscuring situation.
<img width="593" alt="image" src="https://github.com/user-attachments/assets/7e07ba2e-358d-4afd-ba6f-7d21cb927438">

or remove `menu` config.
<img width="904" alt="image" src="https://github.com/user-attachments/assets/86b7f1db-dcfc-4f2c-959e-821116b98399">