### PR TITLE
Fix syntax errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@ cmp.setup {
         -- menu = function() return math.floor(0.45 * vim.o.columns) end,
         menu = 50, -- leading text (labelDetails)
         abbr = 50, -- actual suggestion item
-      }
+      },
       ellipsis_char = '...', -- when popup menu exceed maxwidth, the truncated part would show ellipsis_char instead (must define maxwidth first)
       show_labelDetails = true, -- show labelDetails in menu. Disabled by default
 
       -- The function below will be called before any actual modifications from lspkind
       -- so that you can provide more controls on popup customization. (See [#30](https://github.com/onsails/lspkind-nvim/pull/30))
       before = function (entry, vim_item)
-        ...
+        -- ...
         return vim_item
       end
     })


### PR DESCRIPTION
The code in the readme currently is not valid lua code. With these two small syntax fixes, it can be copy and pasted as valid code. 